### PR TITLE
Throw error message instead of exit code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,27 @@ jobs:
         if: always()
         uses: crazy-max/ghaction-dump-context@v1
 
-  error:
+  error-msg:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Build
+        continue-on-error: true
+        uses: ./
+        with:
+          files: |
+            ./test/config.hcl
+          set: |
+            *.platform=linux/amd64,linux/ppc64le,linux/s390x
+      -
+        name: Dump context
+        if: always()
+        uses: crazy-max/ghaction-dump-context@v1
+
+  error-check:
     runs-on: ubuntu-latest
     steps:
       -

--- a/src/exec.ts
+++ b/src/exec.ts
@@ -7,7 +7,7 @@ export interface ExecResult {
   stderr: string;
 }
 
-export const exec = async (command: string, args: string[] = [], silent: boolean): Promise<ExecResult> => {
+export const exec = async (command: string, args: string[] = [], silent?: boolean): Promise<ExecResult> => {
   let stdout: string = '';
   let stderr: string = '';
 


### PR DESCRIPTION
Display the actual error instead of generic `Error: The process '/usr/bin/docker' failed with exit code 1` error.