### PR TITLE
Add caching input to action

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ Following inputs can be used as `step.with` keys
 | `load`           | Bool     | Load is a shorthand for `--set=*.output=type=docker` (default `false`) |
 | `push`           | Bool     | Push is a shorthand for `--set=*.output=type=registry` (default `false`) |
 | `set`            | List     | List of [targets values to override](https://github.com/docker/buildx/blob/master/docs/reference/buildx_bake.md#set) (eg: `targetpattern.key=value`) |
-| `cacheTo`       | List     | List of [cache destinations](https://github.com/docker/buildx/blob/master/docs/reference/buildx_build.md#cache-to) (eg: `type=local,src=/tmp/.buildx-cache`) |
-| `cacheFrom`      | List     | List of [cache sources](https://github.com/docker/buildx/blob/master/docs/reference/buildx_build.md#cache-from) (eg: `type=local,dest=/tmp/.buildx-cache`) |
+| `cacheTo`       | List     | List of [cache destinations](https://github.com/docker/buildx/blob/master/docs/reference/buildx_build.md#cache-to) (eg: `type=local,src=/tmp/.buildx-cache`) Shorthand for `--set *.cache-to=<target>` |
+| `cacheFrom`      | List     | List of [cache sources](https://github.com/docker/buildx/blob/master/docs/reference/buildx_build.md#cache-from) Shorthand for `--set *.cache-from=<target>` (eg: `type=local,dest=/tmp/.buildx-cache`) |
 
 ## Keep up-to-date with GitHub Dependabot
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ Following inputs can be used as `step.with` keys
 | `load`           | Bool     | Load is a shorthand for `--set=*.output=type=docker` (default `false`) |
 | `push`           | Bool     | Push is a shorthand for `--set=*.output=type=registry` (default `false`) |
 | `set`            | List     | List of [targets values to override](https://github.com/docker/buildx/blob/master/docs/reference/buildx_bake.md#set) (eg: `targetpattern.key=value`) |
+| `cacheTo`       | List     | List of [cache destinations](https://github.com/docker/buildx/blob/master/docs/reference/buildx_build.md#cache-to) (eg: `type=local,src=/tmp/.buildx-cache`) |
+| `cacheFrom`      | List     | List of [cache sources](https://github.com/docker/buildx/blob/master/docs/reference/buildx_build.md#cache-from) (eg: `type=local,dest=/tmp/.buildx-cache`) |
 
 ## Keep up-to-date with GitHub Dependabot
 

--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,12 @@ inputs:
   set:
     description: "List of targets values to override (eg. targetpattern.key=value)"
     required: false
+  cache-from:
+    description: "List of external cache sources for buildx (eg. user/app:cache, type=local,src=path/to/dir)"
+    required: false
+  cache-to:
+    description: "List of cache export destinations for buildx (eg. user/app:cache, type=local,dest=path/to/dir)"
+    required: false
 
 runs:
   using: 'node12'

--- a/dist/index.js
+++ b/dist/index.js
@@ -133,8 +133,8 @@ function getInputs() {
             load: core.getBooleanInput('load'),
             push: core.getBooleanInput('push'),
             set: getInputList('set', true),
-            cacheFrom: yield getInputList('cache-from', true),
-            cacheTo: yield getInputList('cache-to', true)
+            cacheFrom: getInputList('cache-from', true),
+            cacheTo: getInputList('cache-to', true)
         };
     });
 }
@@ -159,10 +159,10 @@ function getBakeArgs(inputs, buildxVersion) {
             args.push('--set', set);
         }));
         yield exports.asyncForEach(inputs.cacheTo, (cacheTo) => __awaiter(this, void 0, void 0, function* () {
-            args.push('--set *.cache-to=', cacheTo);
+            args.push(`--set *.cache-to=${cacheTo}`);
         }));
         yield exports.asyncForEach(inputs.cacheFrom, (cacheFrom) => __awaiter(this, void 0, void 0, function* () {
-            args.push('--set *.cache-from=', cacheFrom);
+            args.push(`--set *.cache-from=${cacheFrom}`);
         }));
         return args;
     });

--- a/dist/index.js
+++ b/dist/index.js
@@ -132,7 +132,9 @@ function getInputs() {
             pull: core.getBooleanInput('pull'),
             load: core.getBooleanInput('load'),
             push: core.getBooleanInput('push'),
-            set: getInputList('set', true)
+            set: getInputList('set', true),
+            cacheFrom: yield getInputList('cache-from', true),
+            cacheTo: yield getInputList('cache-to', true)
         };
     });
 }
@@ -155,6 +157,12 @@ function getBakeArgs(inputs, buildxVersion) {
         }));
         yield exports.asyncForEach(inputs.set, (set) => __awaiter(this, void 0, void 0, function* () {
             args.push('--set', set);
+        }));
+        yield exports.asyncForEach(inputs.cacheTo, (cacheTo) => __awaiter(this, void 0, void 0, function* () {
+            args.push('--set *.cache-to=', cacheTo);
+        }));
+        yield exports.asyncForEach(inputs.cacheFrom, (cacheFrom) => __awaiter(this, void 0, void 0, function* () {
+            args.push('--set *.cache-from=', cacheFrom);
         }));
         return args;
     });

--- a/src/context.ts
+++ b/src/context.ts
@@ -12,6 +12,8 @@ export interface Inputs {
   load: boolean;
   push: boolean;
   set: string[];
+  cacheFrom: string[];
+  cacheTo: string[];
 }
 
 export async function getInputs(): Promise<Inputs> {
@@ -23,7 +25,9 @@ export async function getInputs(): Promise<Inputs> {
     pull: core.getBooleanInput('pull'),
     load: core.getBooleanInput('load'),
     push: core.getBooleanInput('push'),
-    set: getInputList('set', true)
+    set: getInputList('set', true),
+    cacheFrom: await getInputList('cache-from', true),
+    cacheTo: await getInputList('cache-to', true)
   };
 }
 
@@ -42,6 +46,12 @@ async function getBakeArgs(inputs: Inputs, buildxVersion: string): Promise<Array
   });
   await asyncForEach(inputs.set, async set => {
     args.push('--set', set);
+  });
+  await asyncForEach(inputs.cacheTo, async cacheTo => {
+    args.push('--set *.cache-to=', cacheTo);
+  });
+  await asyncForEach(inputs.cacheFrom, async cacheFrom => {
+    args.push('--set *.cache-from=', cacheFrom);
   });
   return args;
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -26,8 +26,8 @@ export async function getInputs(): Promise<Inputs> {
     load: core.getBooleanInput('load'),
     push: core.getBooleanInput('push'),
     set: getInputList('set', true),
-    cacheFrom: await getInputList('cache-from', true),
-    cacheTo: await getInputList('cache-to', true)
+    cacheFrom: getInputList('cache-from', true),
+    cacheTo: getInputList('cache-to', true)
   };
 }
 
@@ -48,10 +48,10 @@ async function getBakeArgs(inputs: Inputs, buildxVersion: string): Promise<Array
     args.push('--set', set);
   });
   await asyncForEach(inputs.cacheTo, async cacheTo => {
-    args.push('--set *.cache-to=', cacheTo);
+    args.push(`--set *.cache-to=${cacheTo}`);
   });
   await asyncForEach(inputs.cacheFrom, async cacheFrom => {
-    args.push('--set *.cache-from=', cacheFrom);
+    args.push(`--set *.cache-from=${cacheFrom}`);
   });
   return args;
 }


### PR DESCRIPTION
Building off #36
I think it would be a nice quality of life improvement to have input for the action that handles caching rather than needing to use the set option.

Example:

```yaml
  - name: Build
    uses: docker/bake-action
    with:
      files: ./docker-bake.hcl
      targets: release
      push: ${{ startsWith(github.ref, 'refs/tags/v') }}
      cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
      cache-from: type=local,src=/tmp/.buildx-cache
```