### PR TITLE
docs(README): clarify default value for 'target'

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Following inputs can be used as `step.with` keys
 | `builder`  | String   | Builder instance (see [setup-buildx](https://github.com/docker/setup-buildx-action) action)                                                          |
 | `files`    | List/CSV | List of [bake definition files](https://github.com/docker/buildx/blob/master/docs/reference/buildx_bake.md#file)                                     |
 | `workdir`  | String   | Working directory of execution                                                                                                                       |
-| `targets`  | List/CSV | List of bake targets                                                                                                                                 |
+| `targets`  | List/CSV | List of bake targets (if empty, Buildx Bake will build target `default`)                                                                                                                                |
 | `no-cache` | Bool     | Do not use cache when building the image (default `false`)                                                                                           |
 | `pull`     | Bool     | Always attempt to pull a newer version of the image (default `false`)                                                                                |
 | `load`     | Bool     | Load is a shorthand for `--set=*.output=type=docker` (default `false`)                                                                               |


### PR DESCRIPTION
## Context
When reading the README, a newcomer might think that there is no default value for the parameter `target`.

This github action has no default value, but **Buildx Bake** has a default value for the parameter `target`, which is `default`.

We could make this explicit in the README. WDYT ?