### PR TITLE
chore: remove CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-*	@crazy-max


### PR DESCRIPTION
Looks like an oversight when the repo has been moved from my account https://github.com/docker/bake-action/pull/8