### PR TITLE
ci: fix workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
       -
         name: Stop docker
         run: |
-          sudo systemctl stop docker
+          sudo systemctl stop docker docker.socket
       -
         name: Build
         id: bake
@@ -116,9 +116,13 @@ jobs:
         name: Checkout
         uses: actions/checkout@v3
       -
-        name: Uninstall moby cli
+        name: Uninstall docker cli
         run: |
-          sudo apt-get purge -y moby-cli moby-buildx
+          if dpkg -s "docker-ce" >/dev/null 2>&1; then
+            sudo dpkg -r --force-depends docker-ce-cli docker-buildx-plugin
+          else
+            sudo apt-get purge -y moby-cli moby-buildx
+          fi
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2


### PR DESCRIPTION
related to: https://github.com/docker/bake-action/actions/runs/6071938351/job/16470977179#step:5:25

![image](https://github.com/docker/bake-action/assets/1951866/41a6303a-8a8a-4960-ab4e-4e5c8979d2a6)

docker-ce packages are now installed on GitHub Runners. Same as https://github.com/docker/setup-buildx-action/commit/93b8ecaa2c1900a3605b90629b56d2208bf1d41f