### PR TITLE
Make files input not mandatory

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
     required: false
   files:
     description: "List of bake definition files"
-    required: true
+    required: false
   workdir:
     description: "Working directory of bake execution"
     required: false


### PR DESCRIPTION
Because it is not and it's causing my workflow to be flagged as invalid.