### PR TITLE
ci: bump gha to latest stable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,7 @@ jobs:
           targets: test
       -
         name: Upload coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           file: ./coverage/clover.xml
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/subaction/list-targets/action.yml
+++ b/subaction/list-targets/action.yml
@@ -25,7 +25,7 @@ runs:
     -
       name: Generate
       id: generate
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       with:
         script: |
           let def;


### PR DESCRIPTION
related to https://github.com/docker/bake-action/actions/runs/8002706537

![image](https://github.com/docker/bake-action/assets/1951866/5dcf3dcc-a7bb-436b-88a0-5accfb8de11b)
