### PR TITLE
ci: disable registry check for load/push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -519,6 +519,8 @@ jobs:
             *.tags=localhost:5000/name/app:latest
       -
         name: Check registry
+        # TODO: enable when --load case fixed (currently overrides --push)
+        if: false
         run: |
           docker buildx imagetools inspect localhost:5000/name/app:latest --format '{{json .}}'
       -


### PR DESCRIPTION
related to https://github.com/docker/bake-action/actions/runs/8269698645/job/22625583954#step:6:8

v0.13.1 fixes a regression with load/push shorthands in https://github.com/docker/buildx/pull/2330. This therefore makes push-load workflow to fail. We can enable it back when https://github.com/docker/buildx/pull/2336 is merged (next v0.14)