### PR TITLE
fix missing runs.post in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -60,3 +60,4 @@ outputs:
 runs:
   using: 'node20'
   main: 'dist/index.js'
+  post: 'dist/index.js'


### PR DESCRIPTION
An oversight introduced in https://github.com/docker/bake-action/pull/46 when implementing post state :flushed: