### PR TITLE
list-targets: Allow passing multi-line files

### DIFF
--- a/.github/workflows/ci-subaction.yml
+++ b/.github/workflows/ci-subaction.yml
@@ -38,9 +38,9 @@ jobs:
         with:
           workdir: ./test/group
       -
-        name: Show matrix
+        name: Show targets
         run: |
-          echo matrix=${{ steps.gen.outputs.matrix }}
+          echo targets=${{ steps.gen.outputs.targets }}
 
   list-targets-group-matrix:
     runs-on: ubuntu-latest
@@ -56,6 +56,26 @@ jobs:
           workdir: ./test/group-matrix
           target: validate
       -
-        name: Show matrix
+        name: Show targets
         run: |
-          echo matrix=${{ steps.gen.outputs.matrix }}
+          echo targets=${{ steps.gen.outputs.targets }}
+
+  list-targets-multi-files:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+      -
+        name: Matrix gen
+        id: gen
+        uses: ./subaction/list-targets
+        with:
+          workdir: ./test/multi-files
+          files: |
+            docker-bake.json
+            docker-bake.hcl
+      -
+        name: Show targets
+        run: |
+          echo targets=${{ steps.gen.outputs.targets }}

--- a/subaction/list-targets/action.yml
+++ b/subaction/list-targets/action.yml
@@ -29,7 +29,7 @@ runs:
       with:
         script: |
           let def;
-          const files = `${{ inputs.files }}` ? `${{ inputs.files }}`.split(',') : [];
+          const files = `${{ inputs.files }}` ? `${{ inputs.files }}`.split(/[\r?\n,]+/).filter(Boolean) : [];
           const target = `${{ inputs.target }}`;
 
           await core.group(`Validating definition`, async () => {

--- a/test/multi-files/docker-bake.hcl
+++ b/test/multi-files/docker-bake.hcl
@@ -1,0 +1,15 @@
+group "default" {
+  targets = ["t3"]
+}
+
+target "t3" {
+  name = "${item.tag}"
+  matrix = {
+    item = t3
+  }
+  args = {
+    VERSION = "${item.version}"
+    DUMMY_ARG = "${item.arg}"
+  }
+  tags = ["${item.tag}"]
+}

--- a/test/multi-files/docker-bake.json
+++ b/test/multi-files/docker-bake.json
@@ -1,0 +1,14 @@
+{
+  "t3": [
+    {
+      "version": "v1",
+      "arg": "v1-value",
+      "tag": "v1-tag"
+    },
+    {
+      "version": "v2",
+      "arg": "v2-value",
+      "tag": "v2-tag"
+    }
+  ]
+}


### PR DESCRIPTION
Previously only comma-separated values ​​were supported:

```yaml
- uses: docker/bake-action/subaction/list-targets@v5
  with:
    files: arg.json,docker-bake.hcl
```

Now we can pass multi-line values, which is much better:

 ```yaml
- uses: docker/bake-action/subaction/list-targets@v5
  with:
    files: |
      arg.json
      docker-bake.hcl
```

I just made a quick change, can anyone review it? Thanks!
