### PR TITLE
ci: stop update-dist reruns after generated dist pushes

### DIFF
--- a/.github/workflows/update-dist.yml
+++ b/.github/workflows/update-dist.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   update-dist:
-    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == github.event.pull_request.head.repo.full_name
+    if: github.actor == 'dependabot[bot]' && github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == github.event.pull_request.head.repo.full_name
     runs-on: ubuntu-latest
     steps:
       -


### PR DESCRIPTION
relates to https://github.com/docker/bake-action/pull/410#issuecomment-4163377746

The job condition in https://github.com/docker/bake-action/blob/5872f2d2b5f70cc837dc1e1d8d50b1ed3ce741e3/.github/workflows/update-dist.yml#L18

Now requires both the PR author and the current event actor to be `dependabot[bot]`, while keeping the same-repository check added in the zizmor cleanup. That means the initial Dependabot-triggered run still updates `dist`, but the follow-up `synchronize` event triggered by `github-actions[bot]` is skipped as before.