### PR TITLE
dependabot: scan matrix subaction

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,9 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/subaction/matrix"
     schedule:
       interval: "daily"
     cooldown:


### PR DESCRIPTION
https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#directories-or-directory--

> For GitHub Actions, use the value /. Dependabot will search the /.github/workflows directory, as well as the action.yml/action.yaml file from the root directory.